### PR TITLE
Update for Node 0.12

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@
 
 	// MODULES //
 
-	var toobusy = require( 'toobusy' ),
+	var toobusy = require( 'toobusy-js' ),
 		pidusage = require( 'pidusage' ),
 		os = require( 'os' );
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "pidusage": "^0.1.0",
-    "toobusy": "^0.2.4"
+    "toobusy-js": "^0.4.0"
   },
   "devDependencies": {
     "chai": "1.x.x",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "1.x.x",
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.0",
-    "mocha": "1.x.x"
+    "mocha": "2.x.x"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
We're using this module to simplify gathering some health metrics (thanks!) but it failed to build on Node 0.12. This just replaces [toobusy](https://github.com/lloyd/node-toobusy) with [toobusy-js](https://github.com/STRML/node-toobusy). Tests pass and the example returns what's expected so I think it was (shockingly) just that easy.
